### PR TITLE
Update configuration.yaml

### DIFF
--- a/docs/source/files/configuration.yaml
+++ b/docs/source/files/configuration.yaml
@@ -67,7 +67,7 @@ spi:
     
 image:
   - file: "https://smart-plant.readthedocs.io/en/v2r1/_images/Lemon_tree_label_page_1.png"
-    id: page_1_background`
+    id: page_1_background
     type: binary
     invert_alpha: true
 


### PR DESCRIPTION
error in esphome: "IDs must only consist of upper/lowercase characters, the underscorecharacter and numbers. The character '`' cannot be used."