### PR TITLE
docs: remove stale external_components note for MAX17043/MAX17048

### DIFF
--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -49,24 +49,16 @@ the one I strongly recommend is the one through the `ESPHome Add-on for Home Ass
    :linenos:
 
 
-.. Important:: 
-    Note that with this example code, the Smart Plant enters into deep-sleep mode if the battery level is under a 95% (lines 393-401), so be aware that if you want to flash it :term:`OTA`, make sure the battery is fully charged or the Smart Plant powered via USB-C.
+.. Important::
+    Note that with this example code, the Smart Plant enters into deep-sleep mode if the battery level is under 95% (see ``consider_deep_sleep`` script at the end of the file), so be aware that if you want to flash it :term:`OTA`, make sure the battery is fully charged or the Smart Plant powered via USB-C.
 
     
 .. Note::
-    The Smart Plant integrates a *battery gauge* sensor (MAX17048), not natively supported by ESPHome at the moment. However by adding the following code, it would work::
-
-        external_components:
-            - source: github://Option-Zero/esphome-components@max17048
-                components: [max17048]
-        sensor:
-            - platform: max17048
-              battery_voltage:
-                name: Battery voltage
-              battery_level:
-                name: Battery level
-              rate:
-                name: Battery discharge rate
+    The Smart Plant integrates a *battery gauge* sensor (MAX17043/MAX17048).
+    ESPHome includes a **native** ``max17043`` component — no ``external_components``
+    are needed. The example configuration above already uses it. The native component
+    also provides a ``sleep_mode`` action used in the ``consider_deep_sleep`` script
+    to put the fuel gauge into low-power mode before entering deep sleep.
 
 
 .. Note::


### PR DESCRIPTION
## Problem

The `programming.rst` documentation contains a Note that says:

> The Smart Plant integrates a *battery gauge* sensor (MAX17048), **not natively supported by ESPHome at the moment**. However by adding the following code, it would work: `external_components: ...`

This note is now **incorrect and actively harmful**:

- ESPHome has had a **native `max17043` component** for some time
- The `configuration.yaml` was already updated to use it in PR #17 (merged Feb 2026), removing the `external_components` dependency
- A new user who reads this note will add an external component that conflicts with the native one, causing a build error

The embedded `literalinclude` of `configuration.yaml` already shows the correct native usage — the Note directly contradicts it.

Also fixed: the `Important` note about deep sleep referenced hard-coded line numbers (`lines 393-401`) that no longer match the file after recent changes. Replaced with a reference to the `consider_deep_sleep` script by name.

## Changes

- `docs/source/programming.rst`: Replace the stale Note with a short accurate statement confirming native ESPHome support
- `docs/source/programming.rst`: Fix the Important note to not reference fragile line numbers

---

> Note: I'm maintaining 8 Smart Plant boards and hit this documentation issue when helping a friend set up their first one. I work with AI assistance (Claude Code) on my multi-plant setup but this doc fix is straightforward.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>