### PR TITLE
fix: migrate image blocks to platform syntax

### DIFF
--- a/docs/source/files/configuration.yaml
+++ b/docs/source/files/configuration.yaml
@@ -73,7 +73,8 @@ spi:
   mosi_pin: GPIO11
     
 image:
-  - file: "https://smart-plant.readthedocs.io/en/v2r1/_images/Lemon_tree_label_page_1.png"
+  - platform: file
+    file: "https://smart-plant.readthedocs.io/en/v2r1/_images/Lemon_tree_label_page_1.png"
     id: page_1_background
     type: binary
     invert_alpha: true

--- a/examples/multi-device/packages/smart_plant_base.yaml
+++ b/examples/multi-device/packages/smart_plant_base.yaml
@@ -142,7 +142,8 @@ spi:
   mosi_pin: GPIO11
 
 image:
-  - file: "${label_image}"
+  - platform: file
+    file: "${label_image}"
     id: page_1_background
     type: BINARY
     invert_alpha: true


### PR DESCRIPTION
## Summary

- add `platform: file` to both `image:` blocks
- preserve the existing image files, IDs, types, and behavior
- prepare for removal of the legacy image syntax in ESPHome 2027.1.0

## Files changed

- `examples/multi-device/packages/smart_plant_base.yaml`
- `docs/source/files/configuration.yaml`

## Validation

- `git diff --check upstream/V2R1...HEAD`
- both changed YAML files parse successfully with custom ESPHome tags
- diff is exactly one commit and two files (`+4/-2`)

This replaces #23, whose head branch accumulated unrelated production work after it was opened.